### PR TITLE
Add Vermilion syntax highlighting for search queries

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -86,3 +86,25 @@
 .code-block {
   @apply bg-gray-100 dark:bg-gray-800 rounded-lg p-3 font-mono text-sm overflow-x-auto border border-gray-200 dark:border-gray-700;
 }
+
+/* Vermilion Syntax Highlighting Theme */
+.syntax-filter {
+  color: #00a0c8;
+}
+
+.syntax-value {
+  color: #FF7867;
+}
+
+.syntax-string {
+  color: #99C794;
+}
+
+.syntax-regex {
+  color: #a96af3;
+}
+
+.syntax-operator {
+  color: #FF7867;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary

- Add syntax highlighting to search query code blocks using the Vermilion color theme
- Highlight filter keywords (`file:`, `repo:`, `patternType:`, `context:`, etc.) in cyan
- Highlight filter values in vermilion orange
- Highlight string literals in green
- Highlight regex special characters in purple

## Test plan

- [x] Verify syntax highlighting renders correctly in dark mode
- [x] Test with various query types (regexp, literal, structural)
- [x] Confirm colors match Vermilion theme specification

## Before
<img width="1414" height="224" alt="CleanShot 2026-01-09 at 11 52 49@2x" src="https://github.com/user-attachments/assets/6f7b94fe-df0a-4d27-9d5d-6d1ad915c6db" />

## After
<img width="1386" height="228" alt="CleanShot 2026-01-09 at 11 52 02@2x" src="https://github.com/user-attachments/assets/fb13ae4f-3227-40e0-97f4-1b31af35c1a7" />
