### PR TITLE
Add .nojekyll step to disable Jekyll processing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Disable Jekyll processing
+        run: touch docs/.nojekyll
+        
       - name: Setup Pages
         uses: actions/configure-pages@v5
 

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M22.5 8L5 18.5V22L15 27.5L5 33V40L22.5 30V22L32.5 16.5L22.5 11V8Z" fill="#F34E3F"/>
+    <path d="M25.5 40L43 29.5V26L33 20.5L43 15V8L25.5 18V26L15.5 31.5L25.5 37V40Z" fill="#FF7867"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a step to create a `.nojekyll` file in the docs folder during the build workflow
- Ensures GitHub Pages doesn't process files with Jekyll, which can interfere with files that start with underscores or other special characters

## Next steps
Go to Settings → Pages in your GitHub repository
Under "Build and deployment", check the Source setting
Change it to "GitHub Actions" if it's set to "Deploy from a branch"

## Test plan
- [ ] Verify "GitHub Actions" is set to "Deploy from a branch"
- [ ] Verify the workflow runs successfully after merge